### PR TITLE
Added split by regex functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ Pooh
 Bob
 ```
 
+You can use a regex to split by using the `-R REGEX_SPLITTER, --regex_splitter REGEX_SPLITTER` option.
+This is useful when you have columns delimited by an indeterminate amount of spaces such as in the file marks.txt
+Note this is only used to split input and the -d delimiter (defaults to tab) is still used to separate columns for the output.
+```sh
+$ cat marks.txt |ppp rec -R '\s+' 'r[1:3]'
+Amit	Physics
+Rahul	Maths
+Shyam	Biology
+Kedar	English
+Hari	History
+```
+
 ### `| ppp csv`
 `csv` is similar to `rec`, but the difference is that while `rec` simply splits the line using the specified DELIMITER like this, `'line.split(DELIMITER))'`, `csv` uses the [csv](https://docs.python.org/3/library/csv.html) library for parsing. Furthermore, `rec` is tab-separated by default, whereas `csv` is comma-separated.
 

--- a/docs/marks.txt
+++ b/docs/marks.txt
@@ -1,0 +1,5 @@
+1) Amit     Physics   80
+2) Rahul    Maths     90
+3) Shyam    Biology   87
+4) Kedar    English   85
+5) Hari     History   89


### PR DESCRIPTION
Allows input to be parsed using a regex while the output still uses the delimiter. Very useful for cases when the input file has an indeterminate amount of white space as the column separator. Code is not elegant and should be refactored. Example file 'marks.txt' added to docs folder and example usage added to README.md 