### PR TITLE
Set up packaging to allow standard installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Publish package to PyPI
+
+on:
+  release:
+    types:
+    - published
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution packages
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+    - name: Install pypa/build
+      run: python -m pip install --user build
+    - name: Build packages
+      run: python -m build
+    - uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist/
+        if-no-files-found: error
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    steps:
+    - name: Download package
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
+    - name: Install dependencies and package
+      run: |
+        python -m pip install ruff pytest
+        python -m pip install --no-index --find-links ./dist/ pypipe-ppp
+    - name: Lint with Ruff
+      run: ruff --output-format=github --target-version=py310 .
+    - name: Test with pytest
+      run: pytest -v -s
+  publish-to-test-pypi:
+    name: Publish packages to Test PyPI
+    runs-on: ubuntu-latest
+    # List the jobs that this one directly depends on:
+    # - build because it needs the package to be built
+    # - test to make sure it doesn't try uploading before tests pass
+    needs:
+    - build
+    - test
+    environment: test-pypi
+    permissions:
+      # this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
+    - name: Publish packages to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        print-hash: true
+  publish-to-pypi:
+    name: Publish packages to PyPI
+    runs-on: ubuntu-latest
+    # List the jobs that this one directly depends on:
+    # - build because it needs the package to be built
+    # - publish-to-test-pypi to make sure it doesn't try the real upload before the test one succeeds
+    needs:
+    - build
+    - publish-to-test-pypi
+    environment: pypi
+    permissions:
+      # this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
+    - name: Publish packages to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        print-hash: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pypipe-ppp"
+dynamic = ["version"]
+description = 'A Python command-line tool for pipeline processing'
+readme = "README.md"
+requires-python = ">=3.6"
+license = "Apache-2.0"
+keywords = []
+authors = [
+  { name = "bugen", email = "paradise.on.paradise@gmail.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.6",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+dependencies = []
+
+[project.urls]
+Documentation = "https://github.com/bugen/pypipe#readme"
+Issues = "https://github.com/bugen/pypipe/issues"
+Source = "https://github.com/bugen/pypipe"
+
+[project.scripts]
+pypipe = "pypipe:main"
+# To support `pipx run`, there should be a console script whose name matches
+# the PyPI name of the package
+pypipe-ppp = "pypipe:main"
+# https://github.com/bugen/pypipe/pull/8#discussion_r1379798279
+ppp = "pypipe:main"
+
+[tool.hatch.version]
+path = "pypipe.py"


### PR DESCRIPTION
This PR adds the metadata needed to build distributable packages (sdist and wheel) for pypipe and a Github Actions workflow that - after suitable configuration - will upload the package to PyPI each time a tag is made.

I'll come back to this and add instructions for how to do that configuration, but at the moment I don't have time for that, so I'm keeping this as a draft for now. I figured I should just post my work in progress so other people have some idea of what I'm planning, and so if this would clash with other PRs people would like to propose, we can cleanly work around any conflicts.

Closes #4