### PR TITLE
Fix TypeError when calling executable scripts

### DIFF
--- a/pypipe.py
+++ b/pypipe.py
@@ -598,7 +598,7 @@ def custom_handler(args):
     exec_code(code, args)
 
 
-def main(argv=None):
+def main(argv=sys.argv[1:]):
     def key_value(s):
         kv = s.split("=", 1)
         return kv[0], kv[1]
@@ -852,4 +852,4 @@ def main(argv=None):
 
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    main()


### PR DESCRIPTION
Maintainer of the [AUR](https://aur.archlinux.org/) packages [pypipe](https://aur.archlinux.org/packages/pypipe) and [pypipe-git](https://aur.archlinux.org/packages/pypipe-git) here.

When I tried to adapt `pypipe-git` to the new hatchling-based workflow, I noticed that running any of the generated executable scripts would result in an error message.

For example:

```sh
$ ppp --version
Traceback (most recent call last):
  File "/usr/bin/ppp", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.11/site-packages/pypipe.py", line 836, in main
    if len(argv) == 0 or argv[0] not in expected_1st_args:
       ^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```

That error seems to be caused by pip’s shim script calling the `main()` function without arguments.

This PR fixes this by setting the default value for the `argv` kwarg to `sys.argv[1:]` inside the signature of the `main` function.
