### PR TITLE
Checkout code and setup Python in pre-release testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
     needs:
     - build
     steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
     - name: Download package
       uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
The release workflow was failing because I forgot to add a step that actually checks out the code before running pre-release testing, so there were no test files there to run. This change fixes that: it checks out the repository before trying to run pytest, so now pytest can find its configuration and the test files and it should be able to actually run.

I also added a setup-python step to prepare the Python interpreter. This is not strictly necessary, I think, but it's a pretty standard thing to have in other projects, and it will be useful if we try to test on specific Python versions in the future.

Fixes #17 