### PR TITLE
Add new installation methods to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ ln -s pypipe.py ppp
 > **Note**
 > pypipe requires Python 3.6 or later.
 
+pypipe can also be installed in the standard way for Python packages, using [pip](https://pip.pypa.io/en/stable/) or any compatible tool such as [pipx](https://pypa.github.io/pipx/).
+```sh
+pipx install pypipe-ppp
+```
+It also supports running directly with pipx without installation.
+```sh
+pipx run pypipe-ppp <args>
+```
+
 You can also use it with [Wasmer](https://wasmer.io/):
 ```sh
 alias ppp="wasmer run bugen/pypipe -- "


### PR DESCRIPTION
This PR changes `README.md` to describe how pypipe can be installed using pip or pipx. I didn't add a whole lot of details because these are standard installation methods for Python packages, and most people will be familiar with them from other uses.

This is the commit that I originally added to #8, but we decided to wait on it until pypipe can be installed from PyPI. So please wait to merge this PR until you decide it's the right time.